### PR TITLE
fix: resolve license inconsistency (fixes #48)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,9 +5,9 @@ description = "Library containing all models used in the naas ecosystem. You can
 authors = ["Maxime Jublou <maxime@naas.ai>"]
 readme = "README.md"
 packages = [{include = "naas_models"}]
-license = "MIT"
+license = "AGPL-3.0-or-later"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
- Update pyproject.toml license from MIT to AGPL-3.0-or-later
- Update PyPI classifier to match AGPL v3+ license
- Ensures consistency with LICENSE file and README badge
- Resolves legal compliance risk identified in issue #48

The LICENSE file contains the full AGPL v3.0 text, README shows AGPL v3.0 badge, but pyproject.toml incorrectly declared MIT license. This fix aligns all license declarations.